### PR TITLE
multiple clicks no longer result in duplicate yelp results being displayed

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -19,11 +19,18 @@ function yelpOpenStatus(businessID) {
     dataType: "json",
     success: function (response) {
       // return string depending on whether business is current open
+      // first, empty the p tag with open status if already created
+      $("#" + businessID + "status").empty();
+      // next, create an element for the business's open status
+      const openStatus = $("<p>").attr("id", "#" + businessID + "status");
+      // and put the open status in that element
       if (response.hours[0].is_open_now) {
-        $("#" + businessID).append($("<p>").text("IS OPEN NOW!"));
+        openStatus.text("IS OPEN NOW").css("color", "green");
       } else {
-        $("#" + businessID).append($("<p>").text("is closed now."));
+        openStatus.text("IS CLOSED NOW").css("color", "#cc0000"); // dark red
       }
+      // append openStatus to the #businessID
+      $("#" + businessID).append(openStatus);
     },
   });
 }
@@ -243,6 +250,8 @@ function yelpSearch(locationStr, catsStr) {
       const state = data.businesses[0].location.state;
       covidAPI(abbrToState(state), latitude, longitude);
       // If our results are greater than 0, continue
+      // start by remove results that may already be displayed
+      $("#results").empty();
       if (totalresults > 0) {
         // Display a header on the page with the number of results
         $("#results").append(
@@ -300,8 +309,6 @@ function yelpSearch(locationStr, catsStr) {
 // Main
 // search button event listener
 $("input.button-primary").click(function (event) {
-  // clear div so that duplicates do not appear from multiple searches
-  $("#results").empty();
   const searchLocation = $("#searchBox").val().trim(); // from form
   let cats = ""; // categories
   $.each($("input[type='checkbox']:checked"), function () {


### PR DESCRIPTION
issues fixed: #12 #13 

both issues were caused by the yelp results div being emptied in the click event listener followed by multiple yelp API calls running asynchronously. this resulted in the empty method being run multiple times on a div that was already empty, then seconds later all the api calls would finish and display the yelp results in the div. by moving the empty method within the yelp api call, it insures the timing matches up with when the div is filled with results.