### PR TITLE
fix bug where 'show 5 more' button is duplicated when starting a new search

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -396,6 +396,8 @@ function yelpSearch(locationStr, catsStr, radius) {
       }
       // start by remove results that may already be displayed
       $("#results").empty();
+      // remove more results button if it exists
+      $(".showMore").remove();
       // If our results are greater than 0, continue
       if (totalresults > 0) {
         // Display a header on the page with the number of results


### PR DESCRIPTION
closes #37 

fix bug by removing the button upon user attempting a new search.